### PR TITLE
FIX: getRecordCertificationId api 주소 명 변경

### DIFF
--- a/src/common/api/record.ts
+++ b/src/common/api/record.ts
@@ -112,7 +112,7 @@ async function getRecordCertificationId(
   success: (date: AxiosResponse) => void,
 ) {
   axiosInstance
-    .get(`/certification?userId=${userId}&certificationId=${certId}`)
+    .get(`/certification/id?userId=${userId}&certificationId=${certId}`)
     .then((data) => {
       success(data);
     })


### PR DESCRIPTION
- certification -> certification/id
 * 권한 해제된 api 사용을 위해서