### PR TITLE
fix: tokenRefresh() 수정

### DIFF
--- a/src/common/api/login.ts
+++ b/src/common/api/login.ts
@@ -36,14 +36,14 @@ async function tokenRefresh() {
       withCredentials: true,
     });
 
-    const { OS } = store.getState().persist.device;
-    if (OS === 'android')
+    const { OS, device } = store.getState().persist.device;
+    if (OS === 'android' && device !== 'pc')
       window.BRIDGE.flushCookie();
-
     const accessToken = response.headers.authorization_access;
     axiosInstance.defaults.headers.authorization_access = `Bearer ${accessToken}`;
     return response.headers.authorization_access;
-  } catch {
+  } catch (e) {
+    console.log("error : ", e);
     console.log('refresh token stale');
     store.dispatch(userActions.signout());
   }


### PR DESCRIPTION
- 웹브라우저 테스트 시 window.BRIDGE.flushCookie(); 로 인해 API 정상적으로 반환받아도 에러 발생

* device !== pc 조건 추가